### PR TITLE
Detection string change to "NOT FOUND"

### DIFF
--- a/whoaint
+++ b/whoaint
@@ -10,7 +10,7 @@ red='\033[0;31m'
 reset='\033[0m'
 results=$(whois $1)
 
-if [[ "${results}" =~ "No match for" ]]; then
+if [[ "${results}" =~ "NOT FOUND" ]]; then
   echo -e "\n${green}Domain ${1} appears to be available! Better buy it...${reset}\n"
 else
   echo -e "\n${red}Domain ${1} is taken. Prolly squatters...${reset}\n"


### PR DESCRIPTION
whois version 5.2.7 outputs "NOT FOUND" when it cant find a whosi record for a domain.
